### PR TITLE
feat: Implement daily health tips refresh and database storage

### DIFF
--- a/app/src/main/java/com/contsol/ayra/data/source/local/database/AppSQLiteHelper.kt
+++ b/app/src/main/java/com/contsol/ayra/data/source/local/database/AppSQLiteHelper.kt
@@ -14,6 +14,7 @@ class AppSQLiteHelper(context: Context) :
         db.execSQL(CREATE_PHOTO_LOG_TABLE)
         // db.execSQL(CREATE_MENSTRUAL_CYCLE_TABLE)
         db.execSQL(CREATE_AI_SUGGESTION_TABLE)
+        db.execSQL(CREATE_HEALTH_TIPS_TABLE)
         db.execSQL(CREATE_KNOWLEDGE_BASE_TABLE)
     }
 
@@ -25,6 +26,7 @@ class AppSQLiteHelper(context: Context) :
         db.execSQL("DROP TABLE IF EXISTS PhotoLog")
         // db.execSQL("DROP TABLE IF EXISTS MenstrualCycle")
         db.execSQL("DROP TABLE IF EXISTS AISuggestion")
+        db.execSQL("DROP TABLE IF EXISTS HealthTips")
         db.execSQL("DROP TABLE IF EXISTS KnowledgeBase")
         onCreate(db)
     }
@@ -87,6 +89,15 @@ class AppSQLiteHelper(context: Context) :
                 date INTEGER NOT NULL,
                 category TEXT NOT NULL,
                 suggestion_text TEXT NOT NULL,
+                expired_time INTEGER NOT NULL
+            );
+        """
+
+        private const val CREATE_HEALTH_TIPS_TABLE = """
+            CREATE TABLE HealthTips (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
                 expired_time INTEGER NOT NULL
             );
         """

--- a/app/src/main/java/com/contsol/ayra/data/source/local/database/dao/HealthTipsDao.kt
+++ b/app/src/main/java/com/contsol/ayra/data/source/local/database/dao/HealthTipsDao.kt
@@ -1,0 +1,100 @@
+package com.contsol.ayra.data.source.local.database.dao
+
+import android.content.ContentValues
+import android.content.Context
+import com.contsol.ayra.data.source.local.database.AppSQLiteHelper
+import com.contsol.ayra.data.source.local.database.model.Tips
+import com.contsol.ayra.utils.getEndOfTheDayTimestamp
+import androidx.core.database.sqlite.transaction
+
+class HealthTipsDao(context: Context) {
+
+    private val dbHelper = AppSQLiteHelper(context)
+
+    fun insert(tips: Tips): Long {
+        val db = dbHelper.writableDatabase
+        val values = ContentValues().apply {
+            put("title", tips.title)
+            put("content", tips.content)
+            put("expired_time", getEndOfTheDayTimestamp())
+        }
+        return db.insert("HealthTips", null, values)
+    }
+
+    fun insertAll(tips: List<Tips>): List<Long> {
+        val db = dbHelper.writableDatabase
+        val insertedIds = mutableListOf<Long>()
+        db.transaction {
+            try {
+                tips.forEach { tip ->
+                    val values = ContentValues().apply {
+                        put("title", tip.title)
+                        put("content", tip.content)
+                        put("expired_time", getEndOfTheDayTimestamp())
+                    }
+                    val id = insert("HealthTips", null, values)
+                    if (id != -1L) {
+                        insertedIds.add(id)
+                    }
+                }
+            } finally {
+            }
+        }
+        return insertedIds
+    }
+
+    fun getAll(): List<Tips> {
+        val db = dbHelper.readableDatabase
+        val currentTime = System.currentTimeMillis()
+        val cursor = db.rawQuery(
+            "SELECT * FROM HealthTips WHERE expired_time > ?",
+            arrayOf(currentTime.toString())
+        )
+        val healthTips = mutableListOf<Tips>()
+
+        cursor.use {
+            while (it.moveToNext()) {
+                val tips = Tips(
+                    title = it.getString(it.getColumnIndexOrThrow("title")),
+                    content = it.getString(it.getColumnIndexOrThrow("content"))
+                )
+                healthTips.add(tips)
+            }
+        }
+
+        return healthTips
+    }
+
+    fun deleteExpiredTips(): Int {
+        val db = dbHelper.writableDatabase
+        val currentTime = System.currentTimeMillis()
+        // Delete tips where the expired_time is in the past
+        return db.delete("HealthTips", "expired_time <= ?", arrayOf(currentTime.toString()))
+    }
+
+    fun deleteAll() {
+        val db = dbHelper.writableDatabase
+        db.delete("HealthTips", null, null)
+    }
+
+    fun replaceAllTips(newTips: List<Tips>) {
+        val db = dbHelper.writableDatabase
+        db.transaction {
+            try {
+                // Delete all existing tips from the "HealthTips" table
+                delete("HealthTips", null, null)
+
+                // Insert new tips
+                newTips.forEach { tip ->
+                    val values = ContentValues().apply {
+                        put("title", tip.title)
+                        put("content", tip.content)
+                        put("expired_time", getEndOfTheDayTimestamp()) // Sets expiry for today
+                    }
+                    insert("HealthTips", null, values)
+                }
+            } finally {
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/contsol/ayra/data/source/local/preference/TipsRefreshPreferences.kt
+++ b/app/src/main/java/com/contsol/ayra/data/source/local/preference/TipsRefreshPreferences.kt
@@ -1,0 +1,42 @@
+package com.contsol.ayra.data.source.local.preference
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "HealthTipsPrefs"
+private const val KEY_LAST_REFRESH_DATE = "last_refresh_date"
+
+object TipsRefreshPreferences {
+
+    private fun getPreferences(context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    private fun getTodayDateString(): String {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        return dateFormat.format(Date())
+    }
+
+    /**
+     * Checks if tips should be refreshed today.
+     * This is true if they haven't been refreshed yet today.
+     */
+    fun shouldRefreshTips(context: Context): Boolean {
+        val prefs = getPreferences(context)
+        val lastRefreshDate = prefs.getString(KEY_LAST_REFRESH_DATE, null)
+        val todayDate = getTodayDateString()
+        return lastRefreshDate != todayDate
+    }
+
+    /**
+     * Marks tips as refreshed for today.
+     */
+    fun markTipsRefreshedToday(context: Context) {
+        val prefs = getPreferences(context)
+        prefs.edit { putString(KEY_LAST_REFRESH_DATE, getTodayDateString()) }
+    }
+}

--- a/app/src/main/java/com/contsol/ayra/utils/Utils.kt
+++ b/app/src/main/java/com/contsol/ayra/utils/Utils.kt
@@ -1,10 +1,20 @@
 package com.contsol.ayra.utils
 
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 
 fun convertTimestampToDate(timestamp: Long): String {
     val date = Date(timestamp * 1000) // Convert seconds to milliseconds
     val format = SimpleDateFormat("HH.mm")
     return format.format(date)
+}
+
+fun getEndOfTheDayTimestamp(): Long {
+    val calendar = Calendar.getInstance()
+    calendar.set(Calendar.HOUR_OF_DAY, 23)
+    calendar.set(Calendar.MINUTE, 59)
+    calendar.set(Calendar.SECOND, 59)
+    calendar.set(Calendar.MILLISECOND, 999)
+    return calendar.timeInMillis
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -117,20 +117,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- Optional: Add page indicators (e.g., using TabLayoutMediator) -->
-<!--    <com.google.android.material.tabs.TabLayout-->
-<!--        android:id="@+id/tab_layout_indicator"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="16dp"-->
-<!--        app:tabBackground="@drawable/tab_pager_indicator"-->
-<!--        android:background="@color/white"-->
-<!--        app:tabGravity="center"-->
-<!--        app:tabIndicatorFullWidth="false"-->
-<!--        app:tabIndicatorHeight="0dp"-->
-<!--        app:layout_constraintTop_toBottomOf="@id/view_pager_tips"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        android:layout_marginTop="8dp"/>-->
+    <ProgressBar
+        android:id="@+id/tipsProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/view_pager_tips"
+        app:layout_constraintBottom_toBottomOf="@id/view_pager_tips"
+        app:layout_constraintStart_toStartOf="@id/view_pager_tips"
+        app:layout_constraintEnd_toEndOf="@id/view_pager_tips" />
 
     <!-- Ringkasan Aktivitas (ensure constraints are updated if needed) -->
     <TextView


### PR DESCRIPTION
This commit introduces a system for fetching, storing, and displaying daily health tips.

**Key changes:**

-   **`TipsRefreshPreferences.kt`:**
    -   Manages SharedPreferences to track the last date tips were refreshed.
    -   `shouldRefreshTips()`: Checks if tips need to be refreshed for the current day.
    -   `markTipsRefreshedToday()`: Updates the last refresh date to today.
-   **`HealthTipsDao.kt`:**
    -   Handles database operations for `HealthTips` (CRUD).
    -   `insert()`, `insertAll()`: Adds new tips with an expiration timestamp for the end of the current day.
    -   `getAll()`: Retrieves non-expired tips.
    -   `deleteExpiredTips()`: Removes tips whose `expired_time` has passed.
    -   `deleteAll()`: Clears all tips.
    -   `replaceAllTips()`: Deletes all existing tips and inserts a new list.
-   **`AppSQLiteHelper.kt`:**
    -   Added `CREATE_HEALTH_TIPS_TABLE` SQL statement to define the `HealthTips` table schema (id, title, content, expired_time).
    -   Included `HealthTips` table creation in `onCreate()` and drop in `onUpgrade()`.
-   **`HomeFragment.kt`:**
    -   Modified `onViewCreated()` to first check LLM readiness, then call `loadAndRefreshTipsIfNeeded()`.
    -   `loadAndRefreshTipsIfNeeded()`:
        -   Uses `TipsRefreshPreferences` to determine if new tips should be fetched.
        -   If refresh is needed:
            -   Displays a `ProgressBar` (`tipsProgressBar`).
            -   Fetches new tips from `llmInferenceManager.getHealthTips()`.
            -   If new tips are available, replaces all tips in the database using `healthTipsDao.replaceAllTips()` and updates the adapter.
            -   Marks tips as refreshed using `TipsRefreshPreferences.markTipsRefreshedToday()`.
            -   If no new tips, loads existing ones or fallback.
        -   If no refresh is needed, loads existing tips from the database via `loadExistingActiveTipsOrFallback()`.
    -   `loadExistingActiveTipsOrFallback()`:
        -   Loads tips from `healthTipsDao.getAll()`.
        -   Updates the adapter or uses fallback tips if the database is empty or an error occurs.
    -   Added `tipsProgressBar` to `fragment_home.xml` for visual feedback during tip loading.
    -   Instantiated `HealthTipsDao`.
-   **`Utils.kt`:**
    -   Added `getEndOfTheDayTimestamp()`: Returns the timestamp for 23:59:59.999 of the current day, used for setting tip expiration.